### PR TITLE
fix(ci): remove registry-url to enable npm OIDC publishing

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -62,7 +62,6 @@ jobs:
         with:
           node-version: 22
           cache: yarn
-          registry-url: https://registry.npmjs.org
 
       - run: yarn install --immutable
 


### PR DESCRIPTION
## Summary

- Remove `registry-url` from `setup-node` in semantic-release job
- `setup-node` with `registry-url` creates `.npmrc` with `${NODE_AUTH_TOKEN}` placeholder, forcing token-based auth instead of OIDC
- Without it, `@semantic-release/npm` v13 uses OIDC provenance authentication (`id-token: write`)

## Test plan

- [ ] PR validation passes (typecheck, lint, tests, build)
- [ ] Merge to main triggers semantic-release with npm OIDC — no `EINVALIDNPMTOKEN`

Closes #3