### PR TITLE
fix: resolve DTS build failure and prettier formatting

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - run: yarn install --immutable
       - run: yarn typecheck

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,9 +22,9 @@ jobs:
       # corepack MUST be enabled before setup-node so Yarn 4 lockfile is discoverable
       - run: corepack enable
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
 
       - run: yarn install --immutable

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -15,9 +15,9 @@ jobs:
       - uses: actions/checkout@v4
       # corepack must be enabled BEFORE setup-node so cache:yarn can find the lockfile
       - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - run: yarn install --immutable
       - run: yarn typecheck
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
       # corepack must be enabled BEFORE setup-node so cache:yarn can find the lockfile
       - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -47,9 +47,9 @@ jobs:
       - uses: actions/checkout@v4
       # corepack must be enabled BEFORE setup-node so cache:yarn can find the lockfile
       - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - run: yarn install --immutable
       - run: yarn test:cov
@@ -67,9 +67,9 @@ jobs:
       - uses: actions/checkout@v4
       # corepack must be enabled BEFORE setup-node so cache:yarn can find the lockfile
       - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - run: yarn install --immutable
       - run: yarn format:check
@@ -84,9 +84,9 @@ jobs:
           fetch-depth: 0
       # corepack must be enabled BEFORE setup-node so cache:yarn can find the lockfile
       - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
       - run: yarn install --immutable
       - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,17 +15,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: yarn
           registry-url: https://registry.npmjs.org
       - run: yarn install --immutable
       - run: yarn build
       - run: yarn test
-      # Auth: NPM_TOKEN (automation token from npmjs.com)
-      # Provenance: OIDC signing via id-token: write permission
-      # Setup: add NPM_TOKEN secret to the "release" environment
-      - run: npm publish --access public --provenance
+      - name: Publish to npm
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if npm view "@structured-id/opaque@${VERSION}" version >/dev/null 2>&1; then
+            echo "Version ${VERSION} already published to npm; skipping."
+            exit 0
+          fi
+          yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,10 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - run: yarn test
+      # Auth: npm trusted publishing via OIDC (id-token: write + environment: release)
+      # Configure at npmjs.com → Package Settings → Publishing Access → Trusted Publishers:
+      #   Organization: structured-id, Repository: opaque
+      #   Workflow: publish.yml, Environment: release
       - name: Publish to npm
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
@@ -30,7 +34,4 @@ jobs:
             echo "Version ${VERSION} already published to npm; skipping."
             exit 0
           fi
-          yarn npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
+          npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,11 +23,9 @@ jobs:
       - run: yarn install --immutable
       - run: yarn build
       - run: yarn test
-      # npm trusted publishing via OIDC — no NPM_TOKEN needed.
-      # Configure trusted publisher at npmjs.com:
-      #   Package: @structured-id/opaque
-      #   Organization: structured-id
-      #   Repository: opaque
-      #   Workflow: publish.yml
-      #   Environment: release
+      # Auth: NPM_TOKEN (automation token from npmjs.com)
+      # Provenance: OIDC signing via id-token: write permission
+      # Setup: add NPM_TOKEN secret to the "release" environment
       - run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,8 @@ jobs:
         with:
           node-version: 24
           cache: yarn
-          registry-url: https://registry.npmjs.org
+          # NO registry-url — it creates .npmrc with NODE_AUTH_TOKEN which
+          # overrides OIDC trusted publishing with an invalid GITHUB_TOKEN
       - run: yarn install --immutable
       - run: yarn build
       - run: yarn test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,14 @@ jobs:
       #   Workflow: publish.yml, Environment: release
       - name: Publish to npm
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          if npm view "@structured-id/opaque@${VERSION}" version >/dev/null 2>&1; then
-            echo "Version ${VERSION} already published to npm; skipping."
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "${PACKAGE_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "Release tag version (${TAG_VERSION}) does not match package.json version (${PACKAGE_VERSION})."
+            exit 1
+          fi
+          if npm view "@structured-id/opaque@${PACKAGE_VERSION}" version >/dev/null 2>&1; then
+            echo "Version ${PACKAGE_VERSION} already published to npm; skipping."
             exit 0
           fi
           npm publish --access public --provenance

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^20.5.0",
     "@eslint/js": "^10.0.1",
-    "@types/node": "^25.5.1",
+    "@types/node": "^25.5.2",
     "@typescript-eslint/eslint-plugin": "^8.58.0",
     "@typescript-eslint/parser": "^8.58.0",
     "@vitest/coverage-v8": "^4.1.2",

--- a/src/testing/performance.ts
+++ b/src/testing/performance.ts
@@ -96,8 +96,8 @@ async function testPolicyValidation(): Promise<OperationTiming> {
     // Validate length
     void (pwd.length >= 8);
     // Check character classes
-    void (/[A-Z]/.test(pwd));
-    void (/[a-z]/.test(pwd));
+    void /[A-Z]/.test(pwd);
+    void /[a-z]/.test(pwd);
     /\d/.test(pwd);
   }
 

--- a/src/testing/performance.ts
+++ b/src/testing/performance.ts
@@ -98,7 +98,7 @@ async function testPolicyValidation(): Promise<OperationTiming> {
     // Check character classes
     void /[A-Z]/.test(pwd);
     void /[a-z]/.test(pwd);
-    /\d/.test(pwd);
+    void /\d/.test(pwd);
   }
 
   const clientTime = performance.now() - clientStart;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",

--- a/yarn.lock
+++ b/yarn.lock
@@ -767,7 +767,7 @@ __metadata:
     "@eslint/js": "npm:^10.0.1"
     "@noble/curves": "npm:^2.0.1"
     "@noble/hashes": "npm:^2.0.1"
-    "@types/node": "npm:^25.5.1"
+    "@types/node": "npm:^25.5.2"
     "@typescript-eslint/eslint-plugin": "npm:^8.58.0"
     "@typescript-eslint/parser": "npm:^8.58.0"
     "@vitest/coverage-v8": "npm:^4.1.2"
@@ -828,12 +828,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^25.5.1":
-  version: 25.5.1
-  resolution: "@types/node@npm:25.5.1"
+"@types/node@npm:^25.5.2":
+  version: 25.5.2
+  resolution: "@types/node@npm:25.5.2"
   dependencies:
     undici-types: "npm:~7.18.0"
-  checksum: 10c0/354b8ddec9a961be9a54eecc5f201f5c686adc2a0d01e9c5ba30786d82186965871a6c3dda66306be1253f3bea492bfe8bf19af06d0ce85ccfbc095cdf5e7f58
+  checksum: 10c0/11e41a85401724cd1a4de6fb7bd4264ec46db10c09fc8cf8d41de4ede0a7063db458348f859ead4ec0929906aa26aaf45a5fef3aa59742ca0521cda9cee52377
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Fix prettier formatting in `src/testing/performance.ts` (extra parens in `void` expressions)
- Add `ignoreDeprecations: "6.0"` to tsconfig.json — fixes TypeScript 6 `baseUrl` deprecation that broke DTS build
- Update `@types/node` ^25.5.1 → ^25.5.2
- Fix npm publish workflow:
  - Remove `registry-url` from setup-node (was overriding OIDC with invalid GITHUB_TOKEN)
  - Add idempotency check using package.json version (not git tag)
  - Validate tag matches package.json before publish
  - Upgrade setup-node v4 → v6, node 22 → 24

Auth: npm OIDC trusted publishing (no tokens needed).

## Test plan

- [x] `yarn build` — CJS, ESM, DTS all pass
- [x] `yarn test` — 303 tests passed
- [x] `yarn format:check` — clean
- [x] `yarn lint` — clean
- [x] `yarn typecheck` — clean

Closes #32
Closes #35